### PR TITLE
Prevent blank task when saving with Enter

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1248,6 +1248,11 @@ export default function BoardPage({
       const firstHalf = content.substring(0, cursorPosition).trim();
       const secondHalf = content.substring(cursorPosition).trim();
 
+      if (!secondHalf) {
+        await handleEditChecklistItem(noteId, itemId, firstHalf);
+        return;
+      }
+
       // Update current item with first half
       const updatedItems = currentNote.checklistItems.map((item) =>
         item.id === itemId ? { ...item, content: firstHalf } : item

--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -45,13 +45,29 @@ export function ChecklistItem({
   showDeleteButton = true,
   className,
 }: ChecklistItemProps) {
+  const handleBlur = () => {
+    if (isEditing && editContent !== undefined && onEdit) {
+      onEdit(item.id, editContent);
+    }
+    onStopEdit?.();
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === "Enter") {
       e.preventDefault();
       const target = e.target as HTMLInputElement;
-      const cursorPosition = target.selectionStart || 0;
+      const cursorPosition = target.selectionStart ?? 0;
       if (onSplit && editContent !== undefined) {
-        onSplit(item.id, editContent, cursorPosition);
+        const hasContentAfterCursor =
+          cursorPosition < editContent.length &&
+          editContent.slice(cursorPosition).trim() !== "";
+        if (hasContentAfterCursor) {
+          onSplit(item.id, editContent, cursorPosition);
+        } else {
+          handleBlur();
+        }
+      } else {
+        handleBlur();
       }
     }
     if (e.key === "Escape") {
@@ -61,13 +77,6 @@ export function ChecklistItem({
       e.preventDefault();
       onDelete?.(item.id);
     }
-  };
-
-  const handleBlur = () => {
-    if (isEditing && editContent !== undefined && onEdit) {
-      onEdit(item.id, editContent);
-    }
-    onStopEdit?.();
   };
 
   return (

--- a/tests/e2e/add-task-button.spec.ts
+++ b/tests/e2e/add-task-button.spec.ts
@@ -432,4 +432,91 @@ test.describe('Add Task Button', () => {
     await expect(newItemInput).not.toBeVisible();
     expect(noteUpdateCalled).toBe(false);
   });
+
+  test('should not create blank item when editing and pressing Enter', async ({ page }) => {
+    let updatedChecklistItems: any[] = [];
+
+    await page.route('**/api/boards/test-board/notes', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            notes: [
+              {
+                id: 'checklist-note',
+                content: '',
+                color: '#fef3c7',
+                done: false,
+                x: 100,
+                y: 100,
+                width: 200,
+                height: 150,
+                checklistItems: [
+                  {
+                    id: 'item-1',
+                    content: 'Existing task',
+                    checked: false,
+                    order: 0,
+                  },
+                ],
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+                user: {
+                  id: 'test-user',
+                  name: 'Test User',
+                  email: 'test@example.com',
+                },
+              },
+            ],
+          }),
+        });
+      }
+    });
+
+    await page.route('**/api/boards/test-board/notes/checklist-note', async (route) => {
+      if (route.request().method() === 'PUT') {
+        const requestBody = await route.request().postDataJSON();
+        updatedChecklistItems = requestBody.checklistItems;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            note: {
+              id: 'checklist-note',
+              content: '',
+              color: '#fef3c7',
+              done: false,
+              x: 100,
+              y: 100,
+              width: 200,
+              height: 150,
+              checklistItems: requestBody.checklistItems,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+              user: {
+                id: 'test-user',
+                name: 'Test User',
+                email: 'test@example.com',
+              },
+            },
+          }),
+        });
+      }
+    });
+
+    await page.goto('/boards/test-board');
+
+    const item = page.locator('text=Existing task');
+    await expect(item).toBeVisible();
+    await item.click();
+
+    const editInput = page.locator('input[value="Existing task"]');
+    await expect(editInput).toBeFocused();
+    await editInput.fill('Edited task');
+    await editInput.press('Enter');
+
+    expect(updatedChecklistItems).toHaveLength(1);
+    expect(updatedChecklistItems[0].content).toBe('Edited task');
+  });
 });


### PR DESCRIPTION
## Summary
- avoid splitting checklist items when pressing Enter with no trailing text
- ensure server-side split handler falls back to simple edit when second half is empty
- add regression test for editing checklist item without creating blank task

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist; playwright installation forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_689725c454148328a9e43123a648e9fb