### PR TITLE
fix: exclude archived notes from boards query

### DIFF
--- a/app/api/boards/[id]/route.ts
+++ b/app/api/boards/[id]/route.ts
@@ -129,7 +129,14 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       data: updateData,
       include: {
         _count: {
-          select: { notes: true },
+          select: {
+            notes: {
+              where: {
+                deletedAt: null,
+                archivedAt: null,
+              },
+            },
+          },
         },
         organization: {
           select: {

--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -37,6 +37,7 @@ export async function GET() {
             notes: {
               where: {
                 deletedAt: null,
+                archivedAt: null,
               },
             },
           },
@@ -96,7 +97,14 @@ export async function POST(request: NextRequest) {
         updatedAt: true,
         organizationId: true,
         _count: {
-          select: { notes: true },
+          select: {
+            notes: {
+              where: {
+                deletedAt: null,
+                archivedAt: null,
+              },
+            },
+          },
         },
       },
     });

--- a/tests/e2e/boards-query.spec.ts
+++ b/tests/e2e/boards-query.spec.ts
@@ -1,0 +1,43 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+test("should exclude archived notes from boards query", async ({
+  authenticatedPage,
+  testPrisma,
+  testContext,
+}) => {
+  const board = await testPrisma.board.create({
+    data: {
+      name: testContext.getBoardName("Test Board"),
+      description: testContext.prefix("Board description"),
+      createdBy: testContext.userId,
+      organizationId: testContext.organizationId,
+    },
+  });
+
+  await testPrisma.note.create({
+    data: {
+      color: "#fef3c7",
+      archivedAt: null,
+      createdBy: testContext.userId,
+      boardId: board.id,
+    },
+  });
+
+  await testPrisma.note.create({
+    data: {
+      color: "#fef3c7",
+      archivedAt: new Date(),
+      createdBy: testContext.userId,
+      boardId: board.id,
+    },
+  });
+
+  const boardsResponse = authenticatedPage.waitForResponse(
+    (resp) => resp.url().includes("/api/boards") && resp.ok()
+  );
+  await authenticatedPage.goto("/dashboard");
+  await boardsResponse;
+
+  const boardCard = authenticatedPage.locator(`[data-board-id="${board.id}"]`);
+  await expect(boardCard).toContainText("1 note");
+});


### PR DESCRIPTION
## Summary
- ignore archived notes when counting board notes
- cover board query behavior with an e2e test

## Testing
- `npm test`
- `npm run test:e2e tests/e2e/boards-query.spec.ts` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1181/chrome-linux/headless_shell)*
- `npx playwright install` *(fails: Download failed: server returned code 403 body 'Forbidden')*

------
https://chatgpt.com/codex/tasks/task_e_689fecbf4144832887a12f0bb1af93ba