### PR TITLE
Improve setup save button UX and add e2e coverage

### DIFF
--- a/app/setup/organization/form.tsx
+++ b/app/setup/organization/form.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { X, Plus } from "lucide-react";
+import { X, Plus, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useUser } from "@/app/contexts/UserContext";
 
@@ -114,7 +114,8 @@ export default function OrganizationSetupForm({ onSubmit }: OrganizationSetupFor
       </div>
 
       <Button type="submit" className="w-full" disabled={isSubmitting}>
-        {isSubmitting ? "Creating..." : hasValidEmails() ? "Save & Send Invites" : "Save"}
+        {isSubmitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+        {isSubmitting ? "Saving..." : hasValidEmails() ? "Save & Send Invites" : "Save"}
       </Button>
     </form>
   );

--- a/app/setup/profile/page.tsx
+++ b/app/setup/profile/page.tsx
@@ -1,10 +1,29 @@
 import { auth } from "@/auth";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { redirect } from "next/navigation";
 import { db } from "@/lib/db";
+import { Loader2 } from "lucide-react";
+import { useFormStatus } from "react-dom";
+
+function SaveButton() {
+  "use client";
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" className="w-full" disabled={pending}>
+      {pending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+      {pending ? "Saving..." : "Save"}
+    </Button>
+  );
+}
 
 async function updateUserName(formData: FormData) {
   "use server";
@@ -101,9 +120,7 @@ export default async function ProfileSetup() {
                   />
                 </div>
 
-                <Button type="submit" className="w-full">
-                  Save
-                </Button>
+                <SaveButton />
               </form>
             </CardContent>
           </Card>

--- a/tests/e2e/setup-save-button.spec.ts
+++ b/tests/e2e/setup-save-button.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from "../fixtures/test-helpers";
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+// Test profile setup save button loading state
+// Ensure button shows "Saving..." and is disabled during submission
+
+test("profile setup save button shows loading state", async ({ page, testContext }) => {
+  await prisma.user.create({
+    data: {
+      id: testContext.userId,
+      email: testContext.userEmail,
+    },
+  });
+  await prisma.session.create({
+    data: {
+      sessionToken: testContext.sessionToken,
+      userId: testContext.userId,
+      expires: new Date(Date.now() + 60 * 60 * 1000),
+    },
+  });
+
+  await page.context().addCookies([
+    {
+      name: "authjs.session-token",
+      value: testContext.sessionToken,
+      domain: "localhost",
+      path: "/",
+      httpOnly: true,
+      secure: false,
+      sameSite: "Lax",
+    },
+  ]);
+
+  await page.goto("/setup/profile");
+  await page.fill("input[name=\"name\"]", "Test User");
+  const submit = page.getByRole("button", { name: "Save" });
+  await submit.click();
+  await expect(page.getByRole("button", { name: "Saving..." })).toBeDisabled();
+  await page.waitForURL("**/setup/organization");
+
+  // cleanup user/session created for test
+  await prisma.session.deleteMany({ where: { userId: testContext.userId } });
+  await prisma.user.deleteMany({ where: { id: testContext.userId } });
+});
+
+// Test organization setup save button loading state
+
+test("organization setup save button shows loading state", async ({ page, testContext }) => {
+  await prisma.user.create({
+    data: {
+      id: testContext.userId,
+      email: testContext.userEmail,
+      name: "Test User",
+    },
+  });
+  await prisma.session.create({
+    data: {
+      sessionToken: testContext.sessionToken,
+      userId: testContext.userId,
+      expires: new Date(Date.now() + 60 * 60 * 1000),
+    },
+  });
+
+  await page.context().addCookies([
+    {
+      name: "authjs.session-token",
+      value: testContext.sessionToken,
+      domain: "localhost",
+      path: "/",
+      httpOnly: true,
+      secure: false,
+      sameSite: "Lax",
+    },
+  ]);
+
+  await page.goto("/setup/organization");
+  await page.fill("#organizationName", "Test Org");
+  const submit = page.getByRole("button", { name: "Save" });
+  await submit.click();
+  await expect(page.getByRole("button", { name: "Saving..." })).toBeDisabled();
+  await page.waitForURL("**/dashboard");
+
+  // set organization id for automatic cleanup
+  const user = await prisma.user.findUnique({ where: { id: testContext.userId } });
+  if (user?.organizationId) {
+    testContext.organizationId = user.organizationId;
+  }
+});


### PR DESCRIPTION
## Summary
- add pending state with spinner to profile setup save button
- enhance organization setup save button with spinner and saving label
- add e2e tests verifying save button loading behaviour

## Testing
- `npm test`
- `npx playwright test tests/e2e/setup-save-button.spec.ts` *(fails: required env vars DATABASE_URL, EMAIL_FROM, AUTH_RESEND_KEY, AUTH_SECRET missing)*
- `docker compose up -d` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a011099bbc83288a822e4bbe1f851c