### PR TITLE
Use useParams for board id

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useMemo } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams, useParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -37,7 +37,7 @@ import {
   filterAndSortNotes,
 } from "@/lib/utils";
 
-export default function BoardPage({ params }: { params: Promise<{ id: string }> }) {
+export default function BoardPage() {
   const [board, setBoard] = useState<Board | null>(null);
   const [notes, setNotes] = useState<Note[]>([]);
   const { resolvedTheme } = useTheme();
@@ -49,7 +49,6 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
   const [showAddBoard, setShowAddBoard] = useState(false);
   const [newBoardName, setNewBoardName] = useState("");
   const [newBoardDescription, setNewBoardDescription] = useState("");
-  const [boardId, setBoardId] = useState<string | null>(null);
   const [isMobile, setIsMobile] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState("");
@@ -81,6 +80,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
   const boardRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { id: boardId } = useParams<{ id: string }>();
 
   useEffect(() => {
     if (!userLoading && !user) {
@@ -152,14 +152,6 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     setSelectedAuthor(urlAuthor);
   };
 
-  useEffect(() => {
-    const initializeParams = async () => {
-      const resolvedParams = await params;
-      setBoardId(resolvedParams.id);
-    };
-    initializeParams();
-  }, [params]);
-
   // Initialize filters from URL on mount
   useEffect(() => {
     initializeFiltersFromURL();
@@ -167,9 +159,7 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
   }, []);
 
   useEffect(() => {
-    if (boardId) {
-      fetchBoardData();
-    }
+    fetchBoardData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [boardId]);
 

--- a/tests/e2e/board-loading.spec.ts
+++ b/tests/e2e/board-loading.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+test.describe("Board Page Loading", () => {
+  test("should fetch board data on initial load", async ({
+    authenticatedPage,
+    testPrisma,
+    testContext,
+  }) => {
+    const board = await testPrisma.board.create({
+      data: {
+        name: testContext.getBoardName("Test Board"),
+        description: testContext.prefix("Board description"),
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    const note = await testPrisma.note.create({
+      data: {
+        color: "#fef3c7",
+        createdBy: testContext.userId,
+        boardId: board.id,
+      },
+    });
+
+    await testPrisma.checklistItem.create({
+      data: {
+        content: testContext.prefix("First item"),
+        checked: false,
+        order: 0,
+        noteId: note.id,
+      },
+    });
+
+    const boardResponse = authenticatedPage.waitForResponse(
+      (resp) => resp.url().includes(`/api/boards/${board.id}`) && resp.ok()
+    );
+    const notesResponse = authenticatedPage.waitForResponse(
+      (resp) => resp.url().includes(`/api/boards/${board.id}/notes`) && resp.ok()
+    );
+
+    await authenticatedPage.goto(`/boards/${board.id}`);
+
+    await Promise.all([boardResponse, notesResponse]);
+
+    await expect(authenticatedPage.locator(`text=${board.name}`)).toBeVisible();
+    await expect(
+      authenticatedPage.locator(`text=${testContext.prefix("First item")}`)
+    ).toBeVisible();
+  });
+});
+


### PR DESCRIPTION
## Summary
- derive board id directly from router params
- fetch board data immediately on mount without temporary state
- add end-to-end test for board loading via route parameters

## Testing
- `npm test`
- `npm run lint`
- `npm run test:e2e` *(fails: missing DATABASE_URL, EMAIL_FROM, AUTH_RESEND_KEY, AUTH_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68a0384b24a88328af590fdb145dfe21