### PR TITLE
fix flaky e2e selectors

### DIFF
--- a/tests/e2e/home-page.spec.ts
+++ b/tests/e2e/home-page.spec.ts
@@ -162,7 +162,9 @@ test.describe("Home Page", () => {
     const originalFinanceText = testContext.prefix("Finance update by Friday");
     const updatedFinanceText = testContext.prefix("Updated Finance deadline");
     await authenticatedPage.getByText(originalFinanceText).click();
-    const editInput = authenticatedPage.locator("textarea").first();
+    const editInput = authenticatedPage
+      .getByTestId(testContext.prefix("101"))
+      .locator("textarea");
     await expect(editInput).toBeVisible();
     const editResponse = authenticatedPage.waitForResponse(
       (resp) =>

--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -513,8 +513,12 @@ test.describe("Note Management", () => {
 
       await authenticatedPage.goto(`/boards/${board.id}`);
 
-      const sourceElement = authenticatedPage.getByTestId(itemA3Id);
-      const targetElement = authenticatedPage.getByTestId(itemA1Id);
+      const sourceElement = authenticatedPage
+        .getByText(testContext.prefix("Item A3"))
+        .locator("..");
+      const targetElement = authenticatedPage
+        .getByText(testContext.prefix("Item A1"))
+        .locator("..");
 
       await expect(sourceElement).toBeVisible();
       await expect(targetElement).toBeVisible();

--- a/tests/e2e/organization-settings.spec.ts
+++ b/tests/e2e/organization-settings.spec.ts
@@ -24,9 +24,10 @@ test.describe("Organization Settings", () => {
     });
 
     await authenticatedPage.goto("/settings/organization");
-
-    // Wait for page to load
-    await expect(authenticatedPage.locator("text=Organization Settings")).toBeVisible();
+    await authenticatedPage.waitForLoadState("networkidle");
+    await expect(
+      authenticatedPage.getByRole("heading", { name: "Organization Settings" })
+    ).toBeVisible();
 
     // Test invalid Slack webhook URL (doesn't contain "slack")
     const slackWebhookInput = authenticatedPage.locator("#slackWebhookUrl");
@@ -67,9 +68,10 @@ test.describe("Organization Settings", () => {
     });
 
     await authenticatedPage.goto("/settings/organization");
-
-    // Wait for page to load
-    await expect(authenticatedPage.locator("text=Organization Settings")).toBeVisible();
+    await authenticatedPage.waitForLoadState("networkidle");
+    await expect(
+      authenticatedPage.getByRole("heading", { name: "Organization Settings" })
+    ).toBeVisible();
 
     // Test valid Slack webhook URL (contains "slack")
     const validSlackUrl =
@@ -115,9 +117,10 @@ test.describe("Organization Settings", () => {
     });
 
     await authenticatedPage.goto("/settings/organization");
-
-    // Wait for page to load
-    await expect(authenticatedPage.locator("text=Organization Settings")).toBeVisible();
+    await authenticatedPage.waitForLoadState("networkidle");
+    await expect(
+      authenticatedPage.getByRole("heading", { name: "Organization Settings" })
+    ).toBeVisible();
 
     // Verify existing URL is loaded
     const slackWebhookInput = authenticatedPage.locator("#slackWebhookUrl");
@@ -166,9 +169,10 @@ test.describe("Organization Settings", () => {
     });
 
     await authenticatedPage.goto("/settings/organization");
-
-    // Wait for page to load
-    await expect(authenticatedPage.locator("text=Organization Settings")).toBeVisible();
+    await authenticatedPage.waitForLoadState("networkidle");
+    await expect(
+      authenticatedPage.getByRole("heading", { name: "Organization Settings" })
+    ).toBeVisible();
 
     // Verify Slack webhook input is disabled for non-admin users
     const slackWebhookInput = authenticatedPage.locator("#slackWebhookUrl");


### PR DESCRIPTION
## Summary
- target checklist edit textarea more precisely in sticky notes demo
- wait for organization settings page to load and use heading-based locator
- locate drag-and-drop checklist items by text content for reordering

## Testing
- `npx playwright test tests/e2e/home-page.spec.ts tests/e2e/organization-settings.spec.ts tests/e2e/notes.spec.ts:461 --project=chromium` *(fails: browserType.launch executable missing & DATABASE_URL env not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a471cd4ff88328b4e1ce992fc6e115