### PR TITLE
feat(board): show last activity time

### DIFF
--- a/app/api/boards/route.ts
+++ b/app/api/boards/route.ts
@@ -32,6 +32,16 @@ export async function GET() {
         createdBy: true,
         createdAt: true,
         updatedAt: true,
+        // Fetch latest note to determine last activity
+        notes: {
+          select: { updatedAt: true },
+          where: {
+            deletedAt: null,
+            archivedAt: null,
+          },
+          orderBy: { updatedAt: "desc" },
+          take: 1,
+        },
         _count: {
           select: {
             notes: {
@@ -46,7 +56,13 @@ export async function GET() {
       orderBy: { createdAt: "desc" },
     });
 
-    return NextResponse.json({ boards });
+    const boardsWithActivity = boards.map((board) => {
+      const lastActivity = board.notes[0]?.updatedAt ?? board.updatedAt;
+      const { notes, ...rest } = board;
+      return { ...rest, lastActivity };
+    });
+
+    return NextResponse.json({ boards: boardsWithActivity });
   } catch (error) {
     console.error("Error fetching boards:", error);
     return NextResponse.json({ error: "Internal server error" }, { status: 500 });

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -41,6 +41,8 @@ import {
 } from "@/components/ui/form";
 import { ProfileDropdown } from "@/components/profile-dropdown";
 import { Skeleton } from "@/components/ui/skeleton";
+import { formatDistanceToNow } from "date-fns";
+import { cn } from "@/lib/utils";
 
 // Dashboard-specific extended types
 export type DashboardBoard = Board & {
@@ -48,6 +50,7 @@ export type DashboardBoard = Board & {
   createdAt: string;
   updatedAt: string;
   isPublic: boolean;
+  lastActivity: string;
   _count: { notes: number };
 };
 
@@ -326,13 +329,21 @@ export default function Dashboard() {
                         </span>
                       </div>
                     </CardHeader>
-                    {board.description && (
-                      <CardContent>
+                    <CardContent>
+                      {board.description && (
                         <p className="text-slate-600 dark:text-zinc-300 truncate">
                           {board.description}
                         </p>
-                      </CardContent>
-                    )}
+                      )}
+                      <p
+                        className={cn(
+                          "text-xs text-muted-foreground dark:text-zinc-400",
+                          board.description ? "mt-2" : ""
+                        )}
+                      >
+                        Last activity {formatDistanceToNow(new Date(board.lastActivity), { addSuffix: true })}
+                      </p>
+                    </CardContent>
                   </Card>
                 </Link>
               ))}
@@ -421,6 +432,7 @@ const DashboardSkeleton = () => {
               <div>
                 <Skeleton className="h-8 w-32 mb-8" />
                 <Skeleton className="h-6 w-64" />
+                <Skeleton className="h-4 w-48 mt-2" />
               </div>
             </div>
           ))}

--- a/tests/e2e/board-card.spec.ts
+++ b/tests/e2e/board-card.spec.ts
@@ -75,5 +75,8 @@ test.describe("Board Card", () => {
     // go to card header then search for span that contain notes count
     const noteCount = newBoardCard.locator("span");
     await expect(noteCount).toHaveText(/^\d+ note(s)?$/);
+
+    // ensure last activity text is visible
+    await expect(newBoardCard.locator("text=Last activity")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- surface each board's latest activity timestamp from the API
- display relative "Last activity" time on dashboard cards and skeleton
- assert board cards include last activity in e2e test

## Testing
- `npm test`
- `npm run test:e2e tests/e2e/board-card.spec.ts` *(fails: Error [ZodError]: "DATABASE_URL" is required)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a4326620832896b855c5be91a4e9