### PR TITLE
fix: await adding checklist items

### DIFF
--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -67,11 +67,11 @@ export function ChecklistItem({
       adjustTextareaHeight(textareaRef.current);
     }
   }, [item.content, isEditing]);
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = async (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
       if (isNewItem && editContent?.trim() && onCreateItem) {
-        onCreateItem(editContent.trim());
+        await onCreateItem(editContent.trim());
       } else {
         const target = e.target as HTMLTextAreaElement;
         target.blur();
@@ -90,13 +90,13 @@ export function ChecklistItem({
     }
   };
 
-  const handleBlur = () => {
+  const handleBlur = async () => {
     if (deletingRef.current) {
       deletingRef.current = false;
       return;
     }
     if (isNewItem && editContent?.trim() && onCreateItem) {
-      onCreateItem(editContent.trim());
+      await onCreateItem(editContent.trim());
     } else if (isEditing && editContent !== undefined && onEdit) {
       onEdit(item.id, editContent);
     }

--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -27,7 +27,7 @@ interface ChecklistItemProps {
   showDeleteButton?: boolean;
   className?: string;
   isNewItem?: boolean;
-  onCreateItem?: (content: string) => void;
+  onCreateItem?: (content: string) => void | Promise<void>;
 }
 
 export function ChecklistItem({

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -328,9 +328,10 @@ export function Note({
   };
 
   const handleCreateNewItem = async (content: string) => {
-    if (content.trim()) {
-      await handleAddChecklistItem(content.trim());
+    const trimmed = content.trim();
+    if (trimmed) {
       setNewItemContent("");
+      await handleAddChecklistItem(trimmed);
     }
   };
 

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -327,9 +327,9 @@ export function Note({
     handleStopEditItem();
   };
 
-  const handleCreateNewItem = (content: string) => {
+  const handleCreateNewItem = async (content: string) => {
     if (content.trim()) {
-      handleAddChecklistItem(content.trim());
+      await handleAddChecklistItem(content.trim());
       setNewItemContent("");
     }
   };

--- a/tests/e2e/home-page.spec.ts
+++ b/tests/e2e/home-page.spec.ts
@@ -199,10 +199,13 @@ test.describe("Home Page", () => {
     await expect(authenticatedPage.getByTestId(testContext.prefix("101"))).not.toBeAttached();
 
     // Verify item was deleted from database
-    const deletedItem = await testPrisma.checklistItem.findFirst({
-      where: { id: testContext.prefix("101") },
-    });
-    expect(deletedItem).toBeNull();
+    await expect
+      .poll(async () =>
+        testPrisma.checklistItem.findFirst({
+          where: { id: testContext.prefix("101") },
+        })
+      )
+      .toBeNull();
 
     // Test 6: Delete entire note
     const deleteNoteButton = authenticatedPage.getByRole("button", {

--- a/tests/e2e/home-page.spec.ts
+++ b/tests/e2e/home-page.spec.ts
@@ -327,12 +327,16 @@ test.describe("Home Page", () => {
       "1"
     );
 
-    // Verify reorder was saved to database
-    const reorderedItems = await testPrisma.checklistItem.findMany({
-      where: { noteId: note2.id },
-      orderBy: { order: "asc" },
+    // Verify reorder was saved to database (allow time for async persistence)
+    await expect
+      .poll(async () =>
+        (
+          await testPrisma.checklistItem.findMany({
+            where: { noteId: note2.id },
+            orderBy: { order: "asc" },
+          })
+        ).map((item) => item.content),
+      )
+      .toEqual([targetElementText, sourceElementText]);
     });
-    expect(reorderedItems[0].content).toBe(targetElementText);
-    expect(reorderedItems[1].content).toBe(sourceElementText);
   });
-});

--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -38,13 +38,18 @@ test.describe("Note Management", () => {
     await initialTextarea.fill(testItemContent);
 
     // Use Tab key to move focus away and trigger blur
+    const addItemResponse = authenticatedPage.waitForResponse(
+      (resp) =>
+        resp.url().includes(`/api/boards/${board.id}/notes/`) &&
+        resp.request().method() === "PUT" &&
+        resp.ok()
+    );
+
     await initialTextarea.press("Tab");
+    await addItemResponse;
 
     // Wait for the content to appear in the UI (this means at least one submission worked)
     await expect(authenticatedPage.getByText(testItemContent)).toBeVisible();
-
-    // Add a small delay to ensure all async operations complete
-    await authenticatedPage.waitForTimeout(1000);
 
     const notes = await testPrisma.note.findMany({
       where: {


### PR DESCRIPTION
## Summary
- await checklist item creation to ensure server update
- allow async checklist creation handler

## Testing
- `npx playwright test tests/e2e/notes.spec.ts -g "should create a note and add checklist items" --project=chromium` *(fails: Required env var DATABASE_URL not set)*

------
https://chatgpt.com/codex/tasks/task_e_68a53bca093c832897e63cac38a9afb3