### PR TITLE
Improve E2E test stability and public board access

### DIFF
--- a/app/public/boards/[id]/page.tsx
+++ b/app/public/boards/[id]/page.tsx
@@ -78,7 +78,9 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
 
   const fetchBoardData = async () => {
     try {
-      const boardResponse = await fetch(`/api/boards/${boardId}`);
+      const boardResponse = await fetch(`/api/boards/${boardId}` , {
+        credentials: "omit",
+      });
       if (boardResponse.status === 404 || boardResponse.status === 403) {
         setBoard(null);
         setLoading(false);
@@ -95,7 +97,9 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
         }
       }
 
-      const notesResponse = await fetch(`/api/boards/${boardId}/notes`);
+      const notesResponse = await fetch(`/api/boards/${boardId}/notes`, {
+        credentials: "omit",
+      });
       if (notesResponse.ok) {
         const { notes } = await notesResponse.json();
         setNotes(notes);

--- a/tests/e2e/archive.spec.ts
+++ b/tests/e2e/archive.spec.ts
@@ -180,8 +180,11 @@ test.describe("Archive Functionality", () => {
       },
     });
 
-    // Go to archive page
+    // Go to archive page and wait for notes to load
     await authenticatedPage.goto("/boards/archive");
+    await authenticatedPage.waitForResponse(
+      (resp) => resp.url().includes("/api/boards/archive/notes") && resp.ok()
+    );
 
     // Scope to the note text to avoid picking up another note
     const noteLocator = authenticatedPage.getByText(

--- a/tests/e2e/board-name-link.spec.ts
+++ b/tests/e2e/board-name-link.spec.ts
@@ -59,6 +59,10 @@ test.describe("Board Name Link Functionality", () => {
     });
 
     await authenticatedPage.goto("/boards/all-notes");
+    await authenticatedPage.waitForResponse(
+      (resp) =>
+        resp.url().includes("/api/boards/all-notes/notes") && resp.ok()
+    );
 
     await expect(
       authenticatedPage.locator(`text=${testContext.prefix("Note from Board 1")}`)

--- a/tests/e2e/board-settings.spec.ts
+++ b/tests/e2e/board-settings.spec.ts
@@ -216,6 +216,10 @@ test.describe("Board Settings", () => {
     });
 
     await page.goto(`/public/boards/${board.id}`);
+    await page.waitForResponse(
+      (resp) =>
+        resp.url().includes(`/api/boards/${board.id}`) && resp.ok()
+    );
 
     await expect(page.locator(`text=${board.name}`)).toBeVisible();
     await expect(page.locator("text=Public").first()).toBeVisible();
@@ -239,6 +243,9 @@ test.describe("Board Settings", () => {
     });
 
     await authenticatedPage.goto(`/public/boards/${board.id}`);
+    await authenticatedPage.waitForResponse(
+      (resp) => resp.url().includes(`/api/boards/${board.id}`)
+    );
 
     await expect(authenticatedPage.locator("text=Board not found")).toBeVisible();
     await expect(

--- a/tests/e2e/home-page.spec.ts
+++ b/tests/e2e/home-page.spec.ts
@@ -298,21 +298,13 @@ test.describe("Home Page", () => {
 
     await expect(sourceElement).toBeVisible();
 
-    const targetBox = await targetElement.boundingBox();
-    if (!targetBox) throw Error("Target element not found");
-
     const reorderResponse = authenticatedPage.waitForResponse(
       (resp) =>
         resp.url().includes(`/api/boards/${demoBoard.id}/notes/`) &&
         resp.request().method() === "PUT" &&
         resp.ok()
     );
-    await sourceElement.hover();
-    await authenticatedPage.mouse.down();
-    await targetElement.hover();
-    await targetElement.hover();
-    await authenticatedPage.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + 5);
-    await authenticatedPage.mouse.up();
+    await sourceElement.dragTo(targetElement);
     await reorderResponse;
 
     await expect(authenticatedPage.getByTestId(targetTestId)).toHaveAttribute(

--- a/tests/e2e/notes.spec.ts
+++ b/tests/e2e/notes.spec.ts
@@ -37,14 +37,19 @@ test.describe("Note Management", () => {
 
     await initialTextarea.fill(testItemContent);
 
+    const addItemResponse = authenticatedPage.waitForResponse(
+      (resp) =>
+        resp.url().includes(`/api/boards/${board.id}/notes/`) &&
+        resp.request().method() === "PUT" &&
+        resp.ok()
+    );
+
     // Use Tab key to move focus away and trigger blur
     await initialTextarea.press("Tab");
+    await addItemResponse;
 
     // Wait for the content to appear in the UI (this means at least one submission worked)
     await expect(authenticatedPage.getByText(testItemContent)).toBeVisible();
-
-    // Add a small delay to ensure all async operations complete
-    await authenticatedPage.waitForTimeout(1000);
 
     const notes = await testPrisma.note.findMany({
       where: {


### PR DESCRIPTION
## Summary
- ensure public board fetches ignore auth credentials
- wait for API responses in archive, board-name-link, board-settings, notes, and home-page tests
- use drag-and-drop helper for note reordering

## Testing
- `npm test`
- `npm run test:e2e` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*


------
https://chatgpt.com/codex/tasks/task_e_68a53bca093c832897e63cac38a9afb3