### PR TITLE
Refactor board ID handling

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -157,6 +157,80 @@ export default function BoardPage() {
     setSelectedAuthor(urlAuthor);
   };
 
+  const fetchBoardData = useCallback(async () => {
+    try {
+      // Fetch all boards for the dropdown
+      let allBoardsResponse: Response;
+      let notesResponse: Response | undefined;
+      let boardResponse: Response | undefined;
+
+      if (boardId === "all-notes") {
+        // For all notes view, create a virtual board object and fetch all notes
+        [allBoardsResponse, notesResponse] = await Promise.all([
+          fetch("/api/boards"),
+          fetch(`/api/boards/all-notes/notes`),
+        ]);
+
+        setBoard({
+          id: "all-notes",
+          name: "All notes",
+          description: "Notes from all boards",
+        });
+      } else if (boardId === "archive") {
+        [allBoardsResponse, notesResponse] = await Promise.all([
+          fetch("/api/boards"),
+          fetch(`/api/boards/archive/notes`),
+        ]);
+
+        // Set virtual board immediately
+        setBoard({
+          id: "archive",
+          name: "Archive",
+          description: "Archived notes from all boards",
+        });
+      } else {
+        [allBoardsResponse, boardResponse, notesResponse] = await Promise.all([
+          fetch("/api/boards"),
+          fetch(`/api/boards/${boardId}`),
+          fetch(`/api/boards/${boardId}/notes`),
+        ]);
+      }
+
+      if (allBoardsResponse.ok) {
+        const { boards } = await allBoardsResponse.json();
+        setAllBoards(boards);
+      }
+
+      if (boardResponse && boardResponse.ok) {
+        const { board } = await boardResponse.json();
+        setBoard(board);
+        setBoardSettings({
+          name: board.name,
+          description: board.description || "",
+          isPublic: (board as { isPublic?: boolean })?.isPublic ?? false,
+          sendSlackUpdates: (board as { sendSlackUpdates?: boolean })?.sendSlackUpdates ?? true,
+        });
+      }
+
+      if (notesResponse && notesResponse.ok) {
+        const { notes } = await notesResponse.json();
+        setNotes(notes);
+      }
+
+      if (boardId && boardId !== "all-notes") {
+        try {
+          localStorage.setItem("gumboard-last-visited-board", boardId);
+        } catch (error) {
+          console.warn("Failed to save last visited board:", error);
+        }
+      }
+    } catch (error) {
+      console.error("Error fetching board data:", error);
+    } finally {
+      setNotesLoading(false);
+    }
+  }, [boardId]);
+
   // Initialize filters from URL on mount
   useEffect(() => {
     initializeFiltersFromURL();
@@ -167,8 +241,7 @@ export default function BoardPage() {
     if (boardId) {
       fetchBoardData();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [boardId]);
+  }, [boardId, fetchBoardData]);
 
   // Close dropdowns when clicking outside and handle escape key
   useEffect(() => {
@@ -273,80 +346,6 @@ export default function BoardPage() {
     const calculatedHeight = Math.max(minHeight, maxBottom + 100);
     return `${calculatedHeight}px`;
   }, [layoutNotes]);
-
-  const fetchBoardData = async () => {
-    try {
-      // Fetch all boards for the dropdown
-      let allBoardsResponse: Response;
-      let notesResponse: Response | undefined;
-      let boardResponse: Response | undefined;
-
-      if (boardId === "all-notes") {
-        // For all notes view, create a virtual board object and fetch all notes
-        [allBoardsResponse, notesResponse] = await Promise.all([
-          fetch("/api/boards"),
-          fetch(`/api/boards/all-notes/notes`),
-        ]);
-
-        setBoard({
-          id: "all-notes",
-          name: "All notes",
-          description: "Notes from all boards",
-        });
-      } else if (boardId === "archive") {
-        [allBoardsResponse, notesResponse] = await Promise.all([
-          fetch("/api/boards"),
-          fetch(`/api/boards/archive/notes`),
-        ]);
-
-        // Set virtual board immediately
-        setBoard({
-          id: "archive",
-          name: "Archive",
-          description: "Archived notes from all boards",
-        });
-      } else {
-        [allBoardsResponse, boardResponse, notesResponse] = await Promise.all([
-          fetch("/api/boards"),
-          fetch(`/api/boards/${boardId}`),
-          fetch(`/api/boards/${boardId}/notes`),
-        ]);
-      }
-
-      if (allBoardsResponse.ok) {
-        const { boards } = await allBoardsResponse.json();
-        setAllBoards(boards);
-      }
-
-      if (boardResponse && boardResponse.ok) {
-        const { board } = await boardResponse.json();
-        setBoard(board);
-        setBoardSettings({
-          name: board.name,
-          description: board.description || "",
-          isPublic: (board as { isPublic?: boolean })?.isPublic ?? false,
-          sendSlackUpdates: (board as { sendSlackUpdates?: boolean })?.sendSlackUpdates ?? true,
-        });
-      }
-
-      if (notesResponse && notesResponse.ok) {
-        const { notes } = await notesResponse.json();
-        setNotes(notes);
-      }
-
-      if (boardId && boardId !== "all-notes") {
-        try {
-          localStorage.setItem("gumboard-last-visited-board", boardId);
-        } catch (error) {
-          console.warn("Failed to save last visited board:", error);
-        }
-      }
-    } catch (error) {
-      console.error("Error fetching board data:", error);
-    } finally {
-      setNotesLoading(false);
-    }
-  };
 
   // Adapter: bridge component Note -> existing update handler
   const handleUpdateNoteFromComponent = async (updatedNote: Note) => {

--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef, useMemo, useCallback } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter, useSearchParams, useParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
@@ -34,10 +34,11 @@ import {
   calculateGridLayout,
   calculateMobileLayout,
   filterAndSortNotes,
+  getBoardId,
 } from "@/lib/utils";
 import { BoardPageSkeleton } from "@/components/board-skeleton";
 
-export default function BoardPage({ params }: { params: Promise<{ id: string }> }) {
+export default function BoardPage() {
   const [board, setBoard] = useState<Board | null>(null);
   const [notes, setNotes] = useState<Note[]>([]);
   const { resolvedTheme } = useTheme();
@@ -49,7 +50,8 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
   const [showAddBoard, setShowAddBoard] = useState(false);
   const [newBoardName, setNewBoardName] = useState("");
   const [newBoardDescription, setNewBoardDescription] = useState("");
-  const [boardId, setBoardId] = useState<string | null>(null);
+  const params = useParams();
+  const boardId = getBoardId(params?.id);
   const [isMobile, setIsMobile] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState("");
@@ -154,14 +156,6 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
     setDateRange({ startDate, endDate });
     setSelectedAuthor(urlAuthor);
   };
-
-  useEffect(() => {
-    const initializeParams = async () => {
-      const resolvedParams = await params;
-      setBoardId(resolvedParams.id);
-    };
-    initializeParams();
-  }, [params]);
 
   // Initialize filters from URL on mount
   useEffect(() => {

--- a/app/public/boards/[id]/page.tsx
+++ b/app/public/boards/[id]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { useRouter, useParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Search } from "lucide-react";
 import Link from "next/link";
@@ -18,13 +18,15 @@ import {
   calculateGridLayout,
   calculateMobileLayout,
   filterAndSortNotes,
+  getBoardId,
 } from "@/lib/utils";
 
-export default function PublicBoardPage({ params }: { params: Promise<{ id: string }> }) {
+export default function PublicBoardPage() {
   const [board, setBoard] = useState<Board | null>(null);
   const [notes, setNotes] = useState<Note[]>([]);
   const [loading, setLoading] = useState(true);
-  const [boardId, setBoardId] = useState<string | null>(null);
+  const params = useParams();
+  const boardId = getBoardId(params?.id);
   const [isMobile, setIsMobile] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
   const [dateRange, setDateRange] = useState<{
@@ -39,44 +41,7 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
   const router = useRouter();
   const { user } = useUser();
 
-  useEffect(() => {
-    const initializeParams = async () => {
-      const resolvedParams = await params;
-      setBoardId(resolvedParams.id);
-    };
-    initializeParams();
-  }, [params]);
-
-  useEffect(() => {
-    if (boardId) {
-      fetchBoardData();
-    }
-  }, [boardId]);
-
-  useEffect(() => {
-    let resizeTimeout: NodeJS.Timeout;
-
-    const checkResponsive = () => {
-      if (typeof window !== "undefined") {
-        const width = window.innerWidth;
-        setIsMobile(width < 768);
-
-        clearTimeout(resizeTimeout);
-        resizeTimeout = setTimeout(() => {
-          setNotes((prevNotes) => [...prevNotes]);
-        }, 50);
-      }
-    };
-
-    checkResponsive();
-    window.addEventListener("resize", checkResponsive);
-    return () => {
-      window.removeEventListener("resize", checkResponsive);
-      clearTimeout(resizeTimeout);
-    };
-  }, []);
-
-  const fetchBoardData = async () => {
+  const fetchBoardData = useCallback(async () => {
     try {
       const boardResponse = await fetch(`/api/boards/${boardId}`);
       if (boardResponse.status === 404 || boardResponse.status === 403) {
@@ -107,7 +72,36 @@ export default function PublicBoardPage({ params }: { params: Promise<{ id: stri
     } finally {
       setLoading(false);
     }
-  };
+  }, [boardId, router]);
+
+  useEffect(() => {
+    if (boardId) {
+      fetchBoardData();
+    }
+  }, [boardId, fetchBoardData]);
+
+  useEffect(() => {
+    let resizeTimeout: NodeJS.Timeout;
+
+    const checkResponsive = () => {
+      if (typeof window !== "undefined") {
+        const width = window.innerWidth;
+        setIsMobile(width < 768);
+
+        clearTimeout(resizeTimeout);
+        resizeTimeout = setTimeout(() => {
+          setNotes((prevNotes) => [...prevNotes]);
+        }, 50);
+      }
+    };
+
+    checkResponsive();
+    window.addEventListener("resize", checkResponsive);
+    return () => {
+      window.removeEventListener("resize", checkResponsive);
+      clearTimeout(resizeTimeout);
+    };
+  }, []);
 
   const uniqueAuthors = useMemo(() => getUniqueAuthors(notes), [notes]);
 

--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { cn } from "../utils";
+import { cn, getBoardId } from "../utils";
 
 describe("cn utility function", () => {
   it("should combine class names correctly", () => {
@@ -24,5 +24,19 @@ describe("cn utility function", () => {
   it("should handle undefined and null values", () => {
     const result = cn("base", undefined, null, "end");
     expect(result).toBe("base end");
+  });
+});
+
+describe("getBoardId", () => {
+  it("returns string when id is string", () => {
+    expect(getBoardId("abc")).toBe("abc");
+  });
+
+  it("returns first element when id is array", () => {
+    expect(getBoardId(["first", "second"])).toBe("first");
+  });
+
+  it("returns null when id is undefined", () => {
+    expect(getBoardId(undefined)).toBeNull();
   });
 });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -21,6 +21,11 @@ export function getBaseUrl(requestOrHeaders?: Request | Headers): string {
   return process.env.AUTH_URL || "http://localhost:3000";
 }
 
+export function getBoardId(id: string | string[] | undefined): string | null {
+  if (!id) return null;
+  return Array.isArray(id) ? id[0] : id;
+}
+
 export function getResponsiveConfig() {
   if (typeof window === "undefined") {
     return { noteWidth: 320, gridGap: 20, containerPadding: 20, notePadding: 16 };

--- a/tests/e2e/board-id.spec.ts
+++ b/tests/e2e/board-id.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+// Ensures board pages handle array-style query parameters without breaking
+// the board ID extraction logic.
+test.describe("Board ID Handling", () => {
+  test("loads board even when query contains multiple id params", async ({
+    authenticatedPage,
+    testPrisma,
+    testContext,
+  }) => {
+    const board = await testPrisma.board.create({
+      data: {
+        name: testContext.getBoardName("Query Board"),
+        description: testContext.prefix("Board with query id"),
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    // Append multiple id query parameters to simulate array-style ids
+    await authenticatedPage.goto(`/boards/${board.id}?id=${board.id}&id=extra`);
+
+    // Should still render the board normally using the path parameter
+    await expect(authenticatedPage.locator(`text=${board.name}`)).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- centralize board ID extraction via new `getBoardId` util
- consume utility in board pages using Next.js `useParams`
- add unit tests for board ID parsing and memoize public board fetch

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a53d06a02c8328abed4e219da0157e