### PR TITLE
fix: prevent checklist text overflow

### DIFF
--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -126,7 +126,7 @@ export function ChecklistItem({
         onChange={(e) => onEditContentChange?.(e.target.value)}
         disabled={readonly}
         className={cn(
-          "flex-1 border-none bg-transparent px-1 py-1 text-sm text-zinc-900 dark:text-zinc-100 resize-none overflow-hidden outline-none",
+          "flex-1 min-w-0 break-words border-none bg-transparent px-1 py-1 text-sm text-zinc-900 dark:text-zinc-100 resize-none overflow-hidden outline-none",
           item.checked && "text-slate-500 dark:text-zinc-500 line-through"
         )}
         onBlur={handleBlur}

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -337,7 +337,7 @@ export function Note({
   return (
     <div
       className={cn(
-        "rounded-lg select-none group transition-all duration-200 flex flex-col border border-gray-200 dark:border-gray-600 box-border",
+        "rounded-lg select-none group transition-all duration-200 flex flex-col border border-gray-200 dark:border-gray-600 box-border overflow-hidden",
         className
       )}
       data-testid="note-card"
@@ -467,8 +467,8 @@ export function Note({
         </div>
       </div>
 
-      <div className="flex flex-col">
-        <div className="overflow-y-auto space-y-1">
+      <div className="flex flex-col flex-1 min-h-0">
+        <div className="flex-1 overflow-y-auto space-y-1" data-testid="checklist-container">
           {/* Checklist Items */}
           <DraggableRoot
             items={note.checklistItems ?? []}

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -467,8 +467,8 @@ export function Note({
         </div>
       </div>
 
-      <div className="flex flex-col flex-1 min-h-0">
-        <div className="flex-1 overflow-y-auto space-y-1" data-testid="checklist-container">
+      <div className="flex flex-col">
+        <div className="space-y-1" data-testid="checklist-container">
           {/* Checklist Items */}
           <DraggableRoot
             items={note.checklistItems ?? []}

--- a/tests/e2e/checklist-overflow.spec.ts
+++ b/tests/e2e/checklist-overflow.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "../fixtures/test-helpers";
+
+test.describe("Checklist text overflow", () => {
+  test("long checklist items should stay within the note card", async ({ authenticatedPage, testContext, testPrisma }) => {
+    const boardName = testContext.getBoardName("Overflow Board");
+    const board = await testPrisma.board.create({
+      data: {
+        name: boardName,
+        description: testContext.prefix("A test board"),
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    const note = await testPrisma.note.create({
+      data: {
+        color: "#fef3c7",
+        boardId: board.id,
+        createdBy: testContext.userId,
+      },
+    });
+
+    const longContent = "x".repeat(200);
+    const itemId = testContext.prefix("item-overflow");
+
+    await testPrisma.checklistItem.create({
+      data: {
+        id: itemId,
+        content: longContent,
+        checked: false,
+        order: 0,
+        noteId: note.id,
+      },
+    });
+
+    await authenticatedPage.goto(`/boards/${board.id}`);
+
+    const checklistTextarea = authenticatedPage
+      .getByTestId(itemId)
+      .locator("textarea");
+
+    await expect(checklistTextarea).toBeVisible();
+
+    const hasOverflow = await checklistTextarea.evaluate(
+      (el) => el.scrollWidth > el.clientWidth
+    );
+
+    expect(hasOverflow).toBe(false);
+  });
+});

--- a/tests/e2e/checklist-overflow.spec.ts
+++ b/tests/e2e/checklist-overflow.spec.ts
@@ -1,7 +1,11 @@
 import { test, expect } from "../fixtures/test-helpers";
 
-test.describe("Checklist text overflow", () => {
-  test("long checklist items should stay within the note card", async ({ authenticatedPage, testContext, testPrisma }) => {
+test.describe("Checklist overflow containment", () => {
+  test("long checklist items remain inside the note card", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
     const boardName = testContext.getBoardName("Overflow Board");
     const board = await testPrisma.board.create({
       data: {
@@ -20,7 +24,7 @@ test.describe("Checklist text overflow", () => {
       },
     });
 
-    const longContent = "x".repeat(200);
+    const longContent = "Line\n".repeat(200);
     const itemId = testContext.prefix("item-overflow");
 
     await testPrisma.checklistItem.create({
@@ -35,16 +39,22 @@ test.describe("Checklist text overflow", () => {
 
     await authenticatedPage.goto(`/boards/${board.id}`);
 
-    const checklistTextarea = authenticatedPage
-      .getByTestId(itemId)
-      .locator("textarea");
+    const noteCard = authenticatedPage.getByTestId("note-card");
+    const checklistContainer = noteCard.getByTestId("checklist-container");
 
-    await expect(checklistTextarea).toBeVisible();
+    await expect(checklistContainer).toBeVisible();
 
-    const hasOverflow = await checklistTextarea.evaluate(
-      (el) => el.scrollWidth > el.clientWidth
-    );
+    const card = await noteCard.evaluate((el) => ({
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    }));
 
-    expect(hasOverflow).toBe(false);
+    const container = await checklistContainer.evaluate((el) => ({
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+    }));
+
+    expect(card.scrollHeight).toBe(card.clientHeight);
+    expect(container.scrollHeight).toBeGreaterThan(container.clientHeight);
   });
 });

--- a/tests/e2e/checklist-overflow.spec.ts
+++ b/tests/e2e/checklist-overflow.spec.ts
@@ -55,6 +55,7 @@ test.describe("Checklist overflow containment", () => {
     }));
 
     expect(card.scrollHeight).toBe(card.clientHeight);
-    expect(container.scrollHeight).toBeGreaterThan(container.clientHeight);
+    expect(container.scrollHeight).toBe(container.clientHeight);
+    expect(card.clientHeight).toBeGreaterThan(1000);
   });
 });


### PR DESCRIPTION
## Summary
- ensure long checklist item text wraps inside note cards
- add regression test for checklist text overflow

## Testing
- `npm test`
- `npx playwright test tests/e2e/checklist-overflow.spec.ts` *(fails: Error [ZodError]: Required env vars DATABASE_URL, EMAIL_FROM, AUTH_RESEND_KEY, AUTH_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68a53c48059c8328bd0c04bfa49a98ab