### PR TITLE
feat: add common alert dialog provider

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -13,15 +13,6 @@ import Link from "next/link";
 import { useState, useEffect, useCallback } from "react";
 import { Plus, Grid3x3, Archive } from "lucide-react";
 import { useRouter } from "next/navigation";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import type { User, Board } from "@/components/note";
 import {
   Dialog,
@@ -41,6 +32,7 @@ import {
 } from "@/components/ui/form";
 import { ProfileDropdown } from "@/components/profile-dropdown";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useAlertDialog } from "@/components/alert-dialog-provider";
 
 // Dashboard-specific extended types
 export type DashboardBoard = Board & {
@@ -65,11 +57,7 @@ export default function Dashboard() {
   const [loading, setLoading] = useState(true);
   const [isAddBoardDialogOpen, setIsAddBoardDialogOpen] = useState(false);
 
-  const [errorDialog, setErrorDialog] = useState<{
-    open: boolean;
-    title: string;
-    description: string;
-  }>({ open: false, title: "", description: "" });
+  const { showAlert } = useAlertDialog();
 
   const router = useRouter();
 
@@ -109,11 +97,11 @@ export default function Dashboard() {
       }
     } catch (error) {
       console.error("Error fetching data:", error);
-      setErrorDialog({
-        open: true,
+      showAlert({
         title: "Failed to load dashboard",
         description:
           "Unable to fetch your boards and user data. Please refresh the page or try again later.",
+        variant: "error",
       });
     } finally {
       setLoading(false);
@@ -146,18 +134,18 @@ export default function Dashboard() {
         setIsAddBoardDialogOpen(false);
       } else {
         const errorData = await response.json();
-        setErrorDialog({
-          open: true,
+        showAlert({
           title: "Failed to create board",
           description: errorData.error || "Failed to create board",
+          variant: "error",
         });
       }
     } catch (error) {
       console.error("Error adding board:", error);
-      setErrorDialog({
-        open: true,
+      showAlert({
         title: "Failed to create board",
         description: "Failed to create board",
+        variant: "error",
       });
     }
   };
@@ -363,29 +351,6 @@ export default function Dashboard() {
         )}
       </div>
 
-      <AlertDialog
-        open={errorDialog.open}
-        onOpenChange={(open) => setErrorDialog({ open, title: "", description: "" })}
-      >
-        <AlertDialogContent className="bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800">
-          <AlertDialogHeader>
-            <AlertDialogTitle className="text-foreground dark:text-zinc-100">
-              {errorDialog.title}
-            </AlertDialogTitle>
-            <AlertDialogDescription className="text-muted-foreground dark:text-zinc-400">
-              {errorDialog.description}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogAction
-              onClick={() => setErrorDialog({ open: false, title: "", description: "" })}
-              className="bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
-            >
-              OK
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { ThemeProvider } from "@/components/theme-provider";
 import "./globals.css";
 import Toaster from "@/components/ui/sonner";
 import { UserProvider } from "./contexts/UserContext";
+import { AlertDialogProvider } from "@/components/alert-dialog-provider";
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -34,8 +35,10 @@ export default function RootLayout({
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
           <SessionProvider>
             <UserProvider>
-              {children}
-              <Toaster richColors position="bottom-right" />
+              <AlertDialogProvider>
+                {children}
+                <Toaster richColors position="bottom-right" />
+              </AlertDialogProvider>
             </UserProvider>
           </SessionProvider>
         </ThemeProvider>

--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -32,6 +32,7 @@ import { useUser } from "@/app/contexts/UserContext";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useRouter } from "next/navigation";
 import { SLACK_WEBHOOK_REGEX } from "@/lib/constants";
+import { useAlertDialog } from "@/components/alert-dialog-provider";
 
 interface OrganizationInvite {
   id: string;
@@ -82,12 +83,7 @@ export default function OrganizationSettingsPage() {
     inviteToken: string;
     inviteName: string;
   }>({ open: false, inviteToken: "", inviteName: "" });
-  const [errorDialog, setErrorDialog] = useState<{
-    open: boolean;
-    title: string;
-    description: string;
-    variant?: "default" | "success" | "error";
-  }>({ open: false, title: "", description: "", variant: "error" });
+  const { showAlert } = useAlertDialog();
   const [creating, setCreating] = useState(false);
 
   useEffect(() => {
@@ -142,8 +138,7 @@ export default function OrganizationSettingsPage() {
     setSaving(true);
     try {
       if (slackWebhookUrl && !SLACK_WEBHOOK_REGEX.test(slackWebhookUrl)) {
-        setErrorDialog({
-          open: true,
+        showAlert({
           title: "Invalid Slack Webhook URL",
           description: "Please enter a valid Slack Webhook URL",
           variant: "error",
@@ -169,18 +164,18 @@ export default function OrganizationSettingsPage() {
         refreshUser();
       } else {
         const errorData = await response.json();
-        setErrorDialog({
-          open: true,
+        showAlert({
           title: "Failed to update organization",
           description: errorData.error || "Failed to update organization",
+          variant: "error",
         });
       }
     } catch (error) {
       console.error("Error updating organization:", error);
-      setErrorDialog({
-        open: true,
+      showAlert({
         title: "Failed to update organization",
         description: "Failed to update organization",
+        variant: "error",
       });
     } finally {
       setSaving(false);
@@ -208,18 +203,18 @@ export default function OrganizationSettingsPage() {
         fetchInvites();
       } else {
         const errorData = await response.json();
-        setErrorDialog({
-          open: true,
+        showAlert({
           title: "Failed to send invite",
           description: errorData.error || "Failed to send invite",
+          variant: "error",
         });
       }
     } catch (error) {
       console.error("Error inviting member:", error);
-      setErrorDialog({
-        open: true,
+      showAlert({
         title: "Failed to send invite",
         description: "Failed to send invite",
+        variant: "error",
       });
     } finally {
       setInviting(false);
@@ -244,18 +239,18 @@ export default function OrganizationSettingsPage() {
         await refreshUser();
       } else {
         const errorData = await response.json();
-        setErrorDialog({
-          open: true,
+        showAlert({
           title: "Failed to remove member",
           description: errorData.error || "Failed to remove member",
+          variant: "error",
         });
       }
     } catch (error) {
       console.error("Error removing member:", error);
-      setErrorDialog({
-        open: true,
+      showAlert({
         title: "Failed to remove member",
         description: "Failed to remove member",
+        variant: "error",
       });
     }
   };
@@ -290,18 +285,18 @@ export default function OrganizationSettingsPage() {
         await refreshUser();
       } else {
         const errorData = await response.json();
-        setErrorDialog({
-          open: true,
+        showAlert({
           title: "Failed to update admin status",
           description: errorData.error || "Failed to update admin status",
+          variant: "error",
         });
       }
     } catch (error) {
       console.error("Error toggling admin status:", error);
-      setErrorDialog({
-        open: true,
+      showAlert({
         title: "Failed to update admin status",
         description: "Failed to update admin status",
+        variant: "error",
       });
     }
   };
@@ -345,18 +340,18 @@ export default function OrganizationSettingsPage() {
         fetchSelfServeInvites();
       } else {
         const errorData = await response.json();
-        setErrorDialog({
-          open: true,
+        showAlert({
           title: "Failed to create invite link",
           description: errorData.error || "Failed to create invite link",
+          variant: "error",
         });
       }
     } catch (error) {
       console.error("Error creating self-serve invite:", error);
-      setErrorDialog({
-        open: true,
+      showAlert({
         title: "Failed to create invite link",
         description: "Failed to create invite link",
+        variant: "error",
       });
     } finally {
       setCreating(false);
@@ -384,18 +379,18 @@ export default function OrganizationSettingsPage() {
         fetchSelfServeInvites();
       } else {
         const errorData = await response.json();
-        setErrorDialog({
-          open: true,
+        showAlert({
           title: "Failed to delete invite link",
           description: errorData.error || "Failed to delete invite link",
+          variant: "error",
         });
       }
     } catch (error) {
       console.error("Error deleting self-serve invite:", error);
-      setErrorDialog({
-        open: true,
+      showAlert({
         title: "Failed to delete invite link",
         description: "Failed to delete invite link",
+        variant: "error",
       });
     }
   };
@@ -404,8 +399,7 @@ export default function OrganizationSettingsPage() {
     const inviteUrl = `${window.location.origin}/join/${inviteToken}`;
     try {
       await navigator.clipboard.writeText(inviteUrl);
-      setErrorDialog({
-        open: true,
+      showAlert({
         title: "Success",
         description: "Invite link copied to clipboard!",
         variant: "success",
@@ -419,8 +413,7 @@ export default function OrganizationSettingsPage() {
       textArea.select();
       document.execCommand("copy");
       document.body.removeChild(textArea);
-      setErrorDialog({
-        open: true,
+      showAlert({
         title: "Success",
         description: "Invite link copied to clipboard!",
         variant: "success",
@@ -909,37 +902,6 @@ export default function OrganizationSettingsPage() {
         </AlertDialogContent>
       </AlertDialog>
 
-      <AlertDialog
-        open={errorDialog.open}
-        onOpenChange={(open) =>
-          setErrorDialog({ open, title: "", description: "", variant: "error" })
-        }
-      >
-        <AlertDialogContent className="bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800">
-          <AlertDialogHeader>
-            <AlertDialogTitle className="text-foreground dark:text-zinc-100">
-              {errorDialog.title}
-            </AlertDialogTitle>
-            <AlertDialogDescription className="text-muted-foreground dark:text-zinc-400">
-              {errorDialog.description}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogAction
-              onClick={() =>
-                setErrorDialog({ open: false, title: "", description: "", variant: "error" })
-              }
-              className={
-                errorDialog.variant === "success"
-                  ? "bg-green-600 hover:bg-green-700 text-white dark:bg-green-600 dark:hover:bg-green-700"
-                  : "bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
-              }
-            >
-              OK
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
     </div>
   );
 }

--- a/components/alert-dialog-provider.tsx
+++ b/components/alert-dialog-provider.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface AlertOptions {
+  title: string;
+  description: string;
+  variant?: "success" | "error";
+}
+
+interface AlertDialogContextType {
+  showAlert: (options: AlertOptions) => void;
+}
+
+const AlertDialogContext = createContext<AlertDialogContextType | undefined>(
+  undefined
+);
+
+export function AlertDialogProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<AlertOptions & { open: boolean }>({
+    open: false,
+    title: "",
+    description: "",
+    variant: "error",
+  });
+
+  const showAlert = ({ title, description, variant = "error" }: AlertOptions) => {
+    setState({ open: true, title, description, variant });
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    setState((prev) => ({ ...prev, open }));
+  };
+
+  return (
+    <AlertDialogContext.Provider value={{ showAlert }}>
+      {children}
+      <AlertDialog open={state.open} onOpenChange={handleOpenChange}>
+        <AlertDialogContent className="bg-white dark:bg-zinc-950 border border-gray-200 dark:border-zinc-800">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="text-foreground dark:text-zinc-100">
+              {state.title}
+            </AlertDialogTitle>
+            <AlertDialogDescription className="text-muted-foreground dark:text-zinc-400">
+              {state.description}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction
+              onClick={() => handleOpenChange(false)}
+              className={
+                state.variant === "success"
+                  ? "bg-green-600 hover:bg-green-700 text-white dark:bg-green-600 dark:hover:bg-green-700"
+                  : "bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
+              }
+            >
+              OK
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </AlertDialogContext.Provider>
+  );
+}
+
+export function useAlertDialog() {
+  const context = useContext(AlertDialogContext);
+  if (!context) {
+    throw new Error("useAlertDialog must be used within an AlertDialogProvider");
+  }
+  return context;
+}
+

--- a/tests/e2e/organization-settings.spec.ts
+++ b/tests/e2e/organization-settings.spec.ts
@@ -145,6 +145,35 @@ test.describe("Organization Settings", () => {
     expect(org?.slackWebhookUrl).toBeNull();
   });
 
+  test("should show success alert when copying invite link", async ({
+    authenticatedPage,
+    testContext,
+    testPrisma,
+  }) => {
+    // Create a self-serve invite
+    await testPrisma.organizationSelfServeInvite.create({
+      data: {
+        id: `invite_${testContext.testId}`,
+        token: `token_${testContext.testId}`,
+        name: "Test Invite",
+        organizationId: testContext.organizationId,
+        createdBy: testContext.userId,
+      },
+    });
+
+    await authenticatedPage.goto("/settings/organization");
+    await expect(authenticatedPage.locator("text=Organization Settings")).toBeVisible();
+
+    // Copy invite link
+    await authenticatedPage.getByTitle("Copy invite link").click();
+
+    await expect(
+      authenticatedPage.locator("text=Invite link copied to clipboard!")
+    ).toBeVisible();
+
+    await authenticatedPage.locator('button:has-text("OK")').click();
+  });
+
   test("should not allow non-admin users to modify Slack webhook URL", async ({
     authenticatedPage,
     testContext,


### PR DESCRIPTION
## Summary
- add global alert dialog provider for success and error messages
- use shared provider across pages and remove inline dialogs
- cover invite link copy flow with new e2e test

## Testing
- `npm test`
- `npm run test:e2e` *(fails: required env vars DATABASE_URL, EMAIL_FROM, AUTH_RESEND_KEY, AUTH_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68a563181a588328abdc6011244571d2