### PR TITLE
fix: improve Send Invite button spacing

### DIFF
--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -647,12 +647,12 @@ export default function OrganizationSettingsPage() {
               className="disabled:bg-gray-400 disabled:cursor-not-allowed bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800 text-white dark:text-zinc-100"
               title={!user?.isAdmin ? "Only admins can invite new team members" : undefined}
             >
-              <UserPlus className="w-4 h-4 mr-2" />
+              <UserPlus className="w-4 h-4 mr-1" />
               {inviting ? (
                 "Inviting..."
               ) : (
                 <>
-                  <span className="hidden lg:inline">Send</span>Invite
+                  <span className="hidden lg:inline">Send&nbsp;</span>Invite
                 </>
               )}
             </Button>

--- a/tests/e2e/organization-settings.spec.ts
+++ b/tests/e2e/organization-settings.spec.ts
@@ -184,4 +184,21 @@ test.describe("Organization Settings", () => {
       "Only admins can update organization settings"
     );
   });
+
+  test("should display responsive text for Send Invite button", async ({ authenticatedPage }) => {
+    await authenticatedPage.goto("/settings/organization");
+
+    // Desktop view shows "Send Invite"
+    await expect(
+      authenticatedPage.getByRole("button", { name: "Send Invite" })
+    ).toBeVisible();
+
+    // Switch to mobile viewport
+    await authenticatedPage.setViewportSize({ width: 375, height: 667 });
+
+    // Mobile view shows "Invite" only
+    await expect(
+      authenticatedPage.getByRole("button", { name: "Invite" })
+    ).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- reduce margin between icon and label in Send Invite button for improved UX
- cover responsive Send Invite button behavior with e2e test

## Testing
- `npm test`
- `npx playwright test tests/e2e/organization-settings.spec.ts` *(fails: Required env vars DATABASE_URL, EMAIL_FROM, AUTH_RESEND_KEY, AUTH_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68a59249b6ec83289a7b0aa86c113520