### PR TITLE
fix: improve invite and delete board button spacing

### DIFF
--- a/app/boards/[id]/page.tsx
+++ b/app/boards/[id]/page.tsx
@@ -1174,8 +1174,8 @@ export default function BoardPage({ params }: { params: Promise<{ id: string }> 
               variant="destructive"
               className="mr-auto bg-red-600 hover:bg-red-700 text-white dark:bg-red-600 dark:hover:bg-red-700"
             >
-              <Trash2 className="w-4 h-4" />
-              Delete <span className="hidden lg:inline">Board</span>
+              <Trash2 className="w-4 h-4 mr-1" />
+              Delete<span className="hidden lg:inline"> Board</span>
             </Button>
             <div className="flex space-x-2 items-center">
               <AlertDialogCancel className="border-gray-400 text-foreground dark:text-zinc-100 dark:border-zinc-700 hover:bg-zinc-100 hover:text-foreground hover:border-gray-200 dark:hover:bg-zinc-800">

--- a/app/settings/organization/page.tsx
+++ b/app/settings/organization/page.tsx
@@ -647,12 +647,12 @@ export default function OrganizationSettingsPage() {
               className="disabled:bg-gray-400 disabled:cursor-not-allowed bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800 text-white dark:text-zinc-100"
               title={!user?.isAdmin ? "Only admins can invite new team members" : undefined}
             >
-              <UserPlus className="w-4 h-4 mr-2" />
+              <UserPlus className="w-4 h-4 mr-1" />
               {inviting ? (
                 "Inviting..."
               ) : (
                 <>
-                  <span className="hidden lg:inline">Send</span>Invite
+                  <span className="hidden lg:inline">Send&nbsp;</span>Invite
                 </>
               )}
             </Button>
@@ -773,8 +773,15 @@ export default function OrganizationSettingsPage() {
               className="disabled:bg-gray-400 disabled:cursor-not-allowed bg-blue-600 hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-800 text-white dark:text-zinc-100"
               title={!user?.isAdmin ? "Only admins can create invite links" : undefined}
             >
-              <Link className="w-4 h-4 mr-2" />
-              {creating ? "Creating..." : "Create Invite Link"}
+              <Link className="w-4 h-4 mr-1" />
+              {creating ? (
+                "Creating..."
+              ) : (
+                <>
+                  <span className="hidden lg:inline">Create Invite Link</span>
+                  <span className="lg:hidden">Create Link</span>
+                </>
+              )}
             </Button>
           </form>
 

--- a/tests/e2e/board-settings.spec.ts
+++ b/tests/e2e/board-settings.spec.ts
@@ -222,6 +222,35 @@ test.describe("Board Settings", () => {
     await expect(page.locator("text=No notes found")).toBeVisible();
   });
 
+  test("should display responsive text for Delete Board button", async ({
+    authenticatedPage,
+    testPrisma,
+    testContext,
+  }) => {
+    const board = await testPrisma.board.create({
+      data: {
+        name: testContext.getBoardName("Delete Board Button"),
+        description: testContext.prefix("Board for delete button test"),
+        sendSlackUpdates: false,
+        createdBy: testContext.userId,
+        organizationId: testContext.organizationId,
+      },
+    });
+
+    await authenticatedPage.goto(`/boards/${board.id}`);
+    await authenticatedPage.getByRole("button", { name: "Board settings" }).click();
+
+    await expect(
+      authenticatedPage.getByRole("button", { name: "Delete Board" })
+    ).toBeVisible();
+
+    await authenticatedPage.setViewportSize({ width: 375, height: 667 });
+
+    await expect(
+      authenticatedPage.getByRole("button", { name: /^Delete$/ })
+    ).toBeVisible();
+  });
+
   test("shows not found for private board on public route", async ({
     authenticatedPage,
     testPrisma,

--- a/tests/e2e/organization-settings.spec.ts
+++ b/tests/e2e/organization-settings.spec.ts
@@ -184,4 +184,38 @@ test.describe("Organization Settings", () => {
       "Only admins can update organization settings"
     );
   });
+
+  test("should display responsive text for Send Invite button", async ({ authenticatedPage }) => {
+    await authenticatedPage.goto("/settings/organization");
+
+    // Desktop view shows "Send Invite"
+    await expect(
+      authenticatedPage.getByRole("button", { name: "Send Invite" })
+    ).toBeVisible();
+
+    // Switch to mobile viewport
+    await authenticatedPage.setViewportSize({ width: 375, height: 667 });
+
+    // Mobile view shows "Invite" only
+    await expect(
+      authenticatedPage.getByRole("button", { name: "Invite" })
+    ).toBeVisible();
+  });
+
+  test("should display responsive text for Create Invite Link button", async ({ authenticatedPage }) => {
+    await authenticatedPage.goto("/settings/organization");
+
+    // Desktop view shows "Create Invite Link"
+    await expect(
+      authenticatedPage.getByRole("button", { name: "Create Invite Link" })
+    ).toBeVisible();
+
+    // Switch to mobile viewport
+    await authenticatedPage.setViewportSize({ width: 375, height: 667 });
+
+    // Mobile view shows "Create Link" only
+    await expect(
+      authenticatedPage.getByRole("button", { name: "Create Link" })
+    ).toBeVisible();
+  });
 });


### PR DESCRIPTION
## Summary
- tighten icon spacing and responsive text for Create Invite Link button
- expand e2e coverage for responsive invite buttons
- tighten spacing and responsive text for Delete Board button
- add e2e test verifying responsive Delete Board button text

## Testing
- `npm test`
- `npx playwright test tests/e2e/board-settings.spec.ts` *(fails: Required env vars DATABASE_URL, EMAIL_FROM, AUTH_RESEND_KEY, AUTH_SECRET)*

------
https://chatgpt.com/codex/tasks/task_e_68a59249b6ec83289a7b0aa86c113520