### PR TITLE
Auto-focus new note's initial to-do

### DIFF
--- a/components/checklist-item.tsx
+++ b/components/checklist-item.tsx
@@ -28,6 +28,7 @@ interface ChecklistItemProps {
   className?: string;
   isNewItem?: boolean;
   onCreateItem?: (content: string) => void;
+  autoFocus?: boolean;
 }
 
 export function ChecklistItem({
@@ -45,6 +46,7 @@ export function ChecklistItem({
   className,
   isNewItem = false,
   onCreateItem,
+  autoFocus = false,
 }: ChecklistItemProps) {
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
   const previousContentRef = React.useRef<string>("");
@@ -67,6 +69,13 @@ export function ChecklistItem({
       adjustTextareaHeight(textareaRef.current);
     }
   }, [item.content, isEditing]);
+
+  React.useEffect(() => {
+    if (isEditing && textareaRef.current && autoFocus) {
+      textareaRef.current.focus();
+      textareaRef.current.select();
+    }
+  }, [isEditing, autoFocus]);
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();

--- a/components/note.tsx
+++ b/components/note.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as React from "react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -87,6 +87,20 @@ export function Note({
   const [editingItem, setEditingItem] = useState<string | null>(null);
   const [editingItemContent, setEditingItemContent] = useState("");
   const [newItemContent, setNewItemContent] = useState("");
+  const [autoFocusItemId, setAutoFocusItemId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (
+      !autoFocusItemId &&
+      note.checklistItems?.length === 1 &&
+      note.checklistItems[0].content === "New to-do"
+    ) {
+      const firstItem = note.checklistItems[0];
+      setEditingItem(firstItem.id);
+      setEditingItemContent(firstItem.content);
+      setAutoFocusItemId(firstItem.id);
+    }
+  }, [note.id, note.checklistItems, autoFocusItemId]);
 
   const canEdit = !readonly && (currentUser?.id === note.user.id || currentUser?.isAdmin);
 
@@ -501,6 +515,7 @@ export function Note({
                     onStopEdit={handleStopEditItem}
                     readonly={readonly}
                     showDeleteButton={canEdit}
+                    autoFocus={autoFocusItemId === item.id}
                   />
                 </DraggableItem>
               ))}
@@ -532,6 +547,7 @@ export function Note({
                 readonly={false}
                 showDeleteButton={false}
                 className="gap-3"
+                autoFocus={false}
               />
             )}
           </DraggableRoot>


### PR DESCRIPTION
## Summary
- auto-select new note's default to-do item
- add auto-focus option to checklist items

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9a29856e483288bdcf870ace7b783