### PR TITLE
Use date-fns for relative time and add edge-case tests

### DIFF
--- a/lib/__tests__/utils.test.ts
+++ b/lib/__tests__/utils.test.ts
@@ -132,4 +132,28 @@ describe("formatLastActivity utility function", () => {
     const result = formatLastActivity(date.toISOString());
     expect(result).toBe("2y 3mo ago");
   });
+
+  it("handles exactly one day difference", () => {
+    const date = new Date("2024-01-14T12:00:00Z");
+    const result = formatLastActivity(date.toISOString());
+    expect(result).toBe("1d ago");
+  });
+
+  it("handles exactly one week difference", () => {
+    const date = new Date("2024-01-08T12:00:00Z");
+    const result = formatLastActivity(date.toISOString());
+    expect(result).toBe("1w ago");
+  });
+
+  it("handles exactly one month difference", () => {
+    const date = new Date("2023-12-15T12:00:00Z");
+    const result = formatLastActivity(date.toISOString());
+    expect(result).toBe("1mo ago");
+  });
+
+  it("handles exactly one year difference", () => {
+    const date = new Date("2023-01-15T12:00:00Z");
+    const result = formatLastActivity(date.toISOString());
+    expect(result).toBe("1y ago");
+  });
 });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,17 @@
 import { Note } from "@/components/note";
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
+import {
+  addMonths,
+  addWeeks,
+  differenceInDays,
+  differenceInHours,
+  differenceInMinutes,
+  differenceInMonths,
+  differenceInSeconds,
+  differenceInWeeks,
+  differenceInYears,
+} from "date-fns";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -9,66 +20,39 @@ export function cn(...inputs: ClassValue[]) {
 export function formatLastActivity(dateString: string): string {
   const date = new Date(dateString);
   const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
 
-  const minute = 60 * 1000;
-  const hour = 60 * minute;
-  const day = 24 * hour;
-  const week = 7 * day;
-  if (diffMs < minute) return "Just now";
+  if (differenceInSeconds(now, date) < 60) return "Just now";
 
-  let years = now.getFullYear() - date.getFullYear();
-  let months = now.getMonth() - date.getMonth();
-
-  if (months < 0) {
-    years--;
-    months += 12;
-  }
-
-  if (now.getDate() < date.getDate()) {
-    months--;
-    if (months < 0) {
-      years--;
-      months += 12;
-    }
-  }
-
+  const years = differenceInYears(now, date);
   if (years > 0) {
+    const months = differenceInMonths(now, date) - years * 12;
     if (years > 1) {
       return months > 0 ? `${years}y ${months}mo ago` : `${years}y ago`;
-    } else {
-      return months > 0 ? `1y ${months}mo ago` : "1y ago";
     }
+    return months > 0 ? `1y ${months}mo ago` : "1y ago";
   }
 
+  const months = differenceInMonths(now, date);
   if (months > 0) {
-    const tempDate = new Date(date);
-    tempDate.setMonth(tempDate.getMonth() + months);
-    const remainingMs = now.getTime() - tempDate.getTime();
-    const weeks = Math.floor(remainingMs / week);
-
+    const weeks = differenceInWeeks(now, addMonths(date, months));
     if (months > 1) {
       return weeks > 0 ? `${months}mo ${weeks}w ago` : `${months}mo ago`;
-    } else {
-      return weeks > 0 ? `1mo ${weeks}w ago` : "1mo ago";
     }
+    return weeks > 0 ? `1mo ${weeks}w ago` : "1mo ago";
   }
 
-  if (diffMs >= week) {
-    const weeks = Math.floor(diffMs / week);
-    const remainingMs = diffMs % week;
-    const days = Math.floor(remainingMs / day);
-
+  const weeks = differenceInWeeks(now, date);
+  if (weeks > 0) {
+    const days = differenceInDays(now, addWeeks(date, weeks));
     if (weeks > 1) {
       return days > 0 ? `${weeks}w ${days}d ago` : `${weeks}w ago`;
-    } else {
-      return days > 0 ? `1w ${days}d ago` : "1w ago";
     }
+    return days > 0 ? `1w ${days}d ago` : "1w ago";
   }
 
-  const days = Math.floor(diffMs / day);
-  const hours = Math.floor((diffMs % day) / hour);
-  const minutes = Math.floor((diffMs % hour) / minute);
+  const days = differenceInDays(now, date);
+  const hours = differenceInHours(now, date) - days * 24;
+  const minutes = differenceInMinutes(now, date) - days * 24 * 60 - hours * 60;
 
   const parts: string[] = [];
 


### PR DESCRIPTION
## Summary
- replace manual relative time math with `date-fns` helpers
- cover additional edge cases (day, week, month, year) in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c50001c4a88328ad83fa8bc3db3e96